### PR TITLE
fix: 

### DIFF
--- a/cms/configuration/storage.md
+++ b/cms/configuration/storage.md
@@ -70,6 +70,18 @@ cms.storage("my_values", new Kv({ kv }));
 export default cms;
 ```
 
+> [!note]
+>
+> If you run into `TypeError: Deno.openKv is not a function`, it means
+> `Deno.openKv() is currently an unstable API`.
+> You need to add the unstable key in deno.json ([info](https://docs.deno.com/runtime/reference/cli/unstable_flags/#configuring-flags-in-deno.json)):
+> ```
+> {
+>   "unstable": ["kv"]
+> }
+> ```
+
+
 ## GitHub
 
 Allows to write and read values directly from a GitHub repository using the


### PR DESCRIPTION
Add hints for OpenKv "TypeError: Deno.openKv is not a function. Deno.openKv() is an unstable API."